### PR TITLE
Add initial MVP backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,18 @@ def nearest(lat: float = Query(...), lon: float = Query(...)):
 - Integrate bike-lane status feeds.
 - Optional Apple Watch / Wear OS support.
 
+
+## Running the MVP Backend
+
+Install dependencies and start the server:
+
+```bash
+pip install -r backend/requirements.txt
+uvicorn backend.main:app --reload
+```
+
+The `/nearest` endpoint expects `lat` and `lon` query parameters and returns the closest pump from the sample dataset.
+
+## MVP React Native App
+
+The `frontend` folder contains a minimal `App.tsx` that fetches from the backend. Use Expo or your preferred React Native setup to run it.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,42 @@
+import json
+from math import radians, sin, cos, sqrt, atan2
+from pathlib import Path
+from fastapi import FastAPI, Query
+from fastapi.middleware.cors import CORSMiddleware
+
+DATA_PATH = Path(__file__).resolve().parent.parent / "data" / "pumps.json"
+
+app = FastAPI(title="Bicycle Pump API")
+
+# Allow all origins for development
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+with open(DATA_PATH) as f:
+    PUMPS = json.load(f)
+
+
+def haversine(lat1, lon1, lat2, lon2):
+    R = 6371000  # meters
+    phi1, phi2 = radians(lat1), radians(lat2)
+    dphi = radians(lat2 - lat1)
+    dlambda = radians(lon2 - lon1)
+    a = sin(dphi / 2) ** 2 + cos(phi1) * cos(phi2) * sin(dlambda / 2) ** 2
+    return 2 * R * atan2(sqrt(a), sqrt(1 - a))
+
+
+@app.get("/nearest")
+async def nearest(lat: float = Query(...), lon: float = Query(...)):
+    closest = None
+    min_dist = float("inf")
+    for pump in PUMPS:
+        dist = haversine(lat, lon, pump["lat"], pump["lon"])
+        if dist < min_dist:
+            min_dist = dist
+            closest = pump
+    return {"pump": closest, "distance": round(min_dist, 1)}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/data/pumps.json
+++ b/data/pumps.json
@@ -1,0 +1,5 @@
+[
+  {"id": 1, "name": "Town Square Pump", "lat": 55.6761, "lon": 12.5683},
+  {"id": 2, "name": "University Pump", "lat": 55.6805, "lon": 12.5710},
+  {"id": 3, "name": "Harbor Pump", "lat": 55.6750, "lon": 12.5800}
+]

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+interface PumpInfo {
+  id: number;
+  name: string;
+  lat: number;
+  lon: number;
+}
+
+type ApiResponse = {
+  pump: PumpInfo;
+  distance: number;
+};
+
+export default function App() {
+  const [data, setData] = useState<ApiResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    navigator.geolocation.getCurrentPosition(
+      async ({ coords }) => {
+        try {
+          const res = await fetch(
+            `http://localhost:8000/nearest?lat=${coords.latitude}&lon=${coords.longitude}`
+          );
+          setData(await res.json());
+        } catch (err) {
+          setError('Failed to fetch');
+        }
+      },
+      () => setError('Location permission denied')
+    );
+  }, []);
+
+  if (error) return <Text>{error}</Text>;
+  if (!data) return <Text>Loading...</Text>;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{data.pump.name}</Text>
+      <Text>{data.distance} meters away</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
## Summary
- add sample dataset of bicycle pump locations
- implement FastAPI backend with `/nearest` endpoint
- add React Native app that queries backend for nearest pump
- document how to run the MVP

## Testing
- `pip install -r backend/requirements.txt`
- `uvicorn backend.main:app --port 8000 --reload &`
- `curl -s "http://127.0.0.1:8000/nearest?lat=55.676&lon=12.569"`

------
https://chatgpt.com/codex/tasks/task_e_686c35f90610832ca012e99903535889