### PR TITLE
Add pump list endpoint and list UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ uvicorn backend.main:app --reload
 
 The `/nearest` endpoint expects `lat` and `lon` query parameters and returns the closest pump from the sample dataset.
 
+Use `/pumps?lat=<lat>&lon=<lon>` to get all pumps sorted by distance with a distance field. Omitting the parameters returns the full dataset unsorted.
+
 ## MVP React Native App
 
-The `frontend` folder contains a minimal `App.tsx` that fetches from the backend. Use Expo or your preferred React Native setup to run it.
+The `frontend` folder contains a minimal `App.tsx` that fetches all pumps from the backend and displays them in a list ordered by distance from your current location. Use Expo or your preferred React Native setup to run it.

--- a/backend/main.py
+++ b/backend/main.py
@@ -40,3 +40,18 @@ async def nearest(lat: float = Query(...), lon: float = Query(...)):
             min_dist = dist
             closest = pump
     return {"pump": closest, "distance": round(min_dist, 1)}
+
+
+@app.get("/pumps")
+async def list_pumps(lat: float | None = Query(None), lon: float | None = Query(None)):
+    """Return all pumps. If lat and lon are provided, pumps are returned with a
+    distance field and sorted by that distance."""
+
+    pumps = PUMPS.copy()
+    if lat is not None and lon is not None:
+        for p in pumps:
+            p["distance"] = haversine(lat, lon, p["lat"], p["lon"])
+        pumps.sort(key=lambda x: x["distance"])
+        for p in pumps:
+            p["distance"] = round(p["distance"], 1)
+    return {"pumps": pumps}

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
 
 interface PumpInfo {
   id: number;
   name: string;
   lat: number;
   lon: number;
+  distance?: number;
 }
 
 type ApiResponse = {
-  pump: PumpInfo;
-  distance: number;
+  pumps: PumpInfo[];
 };
 
 export default function App() {
@@ -22,10 +22,10 @@ export default function App() {
       async ({ coords }) => {
         try {
           const res = await fetch(
-            `http://localhost:8000/nearest?lat=${coords.latitude}&lon=${coords.longitude}`
+            `http://localhost:8000/pumps?lat=${coords.latitude}&lon=${coords.longitude}`
           );
           setData(await res.json());
-        } catch (err) {
+        } catch {
           setError('Failed to fetch');
         }
       },
@@ -36,10 +36,22 @@ export default function App() {
   if (error) return <Text>{error}</Text>;
   if (!data) return <Text>Loading...</Text>;
 
+  const renderItem = ({ item }: { item: PumpInfo }) => (
+    <View style={styles.item}>
+      <Text style={styles.name}>{item.name}</Text>
+      {item.distance !== undefined && (
+        <Text>{item.distance} m away</Text>
+      )}
+    </View>
+  );
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>{data.pump.name}</Text>
-      <Text>{data.distance} meters away</Text>
+      <FlatList
+        data={data.pumps}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={renderItem}
+      />
     </View>
   );
 }
@@ -47,11 +59,15 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    paddingTop: 50,
   },
-  title: {
-    fontSize: 20,
+  item: {
+    padding: 16,
+    borderBottomColor: '#ccc',
+    borderBottomWidth: 1,
+  },
+  name: {
+    fontSize: 18,
     fontWeight: 'bold',
   },
 });


### PR DESCRIPTION
## Summary
- add `/pumps` endpoint to return all pumps optionally sorted by distance
- update React Native app to show list of pumps
- document new API in README

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_686c38194898832c88a0a4826545ee00